### PR TITLE
Fix printf macros for win32

### DIFF
--- a/account-data.cpp
+++ b/account-data.cpp
@@ -107,8 +107,8 @@ void TdAccountData::addChat(TdChatPtr chat)
         auto pContact = std::find(m_contactUserIdsNoChat.begin(), m_contactUserIdsNoChat.end(),
                                   privType.user_id_);
         if (pContact != m_contactUserIdsNoChat.end()) {
-            purple_debug_misc(config::pluginId, "Private chat (id %lld) now known for user %d\n",
-                              (long long)chat->id_, (int)privType.user_id_);
+            purple_debug_misc(config::pluginId, "Private chat (id %" G_GUINT64_FORMAT ") now known for user %d\n",
+                              chat->id_, (int)privType.user_id_);
             m_contactUserIdsNoChat.erase(pContact);
         }
     }
@@ -304,7 +304,7 @@ void TdAccountData::getActiveChats(std::vector<const td::td_api::chat *> &chats)
     for (int64_t chatId: m_activeChats) {
         const td::td_api::chat *chat = getChat(chatId);
         if (!chat) {
-            purple_debug_warning(config::pluginId, "Received unknown chat id %lld\n", (long long)chatId);
+            purple_debug_warning(config::pluginId, "Received unknown chat id %" G_GUINT64_FORMAT "\n", chatId);
             continue;
         }
 

--- a/chat-info.cpp
+++ b/chat-info.cpp
@@ -39,7 +39,7 @@ std::string getChatName(const td::td_api::chat &chat)
 GHashTable *getChatComponents(const td::td_api::chat &chat)
 {
     char name[32];
-    snprintf(name, sizeof(name)-1, "chat%lld", (long long)chat.id_);
+    snprintf(name, sizeof(name)-1, "chat%" G_GUINT64_FORMAT "", chat.id_);
     name[sizeof(name)-1] = '\0';
 
     GHashTable *table = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, g_free);
@@ -61,7 +61,7 @@ int64_t getTdlibChatId(const char *chatName)
 {
     if (chatName && !strncmp(chatName, "chat", 4)) {
         long long id;
-        if (sscanf(chatName+4, "%lld", &id) == 1)
+        if (sscanf(chatName+4, "%" G_GUINT64_FORMAT "", &id) == 1)
             return id;
     }
 

--- a/td-client.cpp
+++ b/td-client.cpp
@@ -309,7 +309,7 @@ void PurpleTdClient::setPurpleConnectionUpdating()
 
 void PurpleTdClient::getContactsResponse(uint64_t requestId, td::td_api::object_ptr<td::td_api::Object> object)
 {
-    purple_debug_misc(config::pluginId, "getContacts response to request %llu\n", (unsigned long long)requestId);
+    purple_debug_misc(config::pluginId, "getContacts response to request %" G_GUINT64_FORMAT "\n", requestId);
     if (object && (object->get_id() == td::td_api::users::ID)) {
         td::td_api::object_ptr<td::td_api::users> users = td::move_tl_object_as<td::td_api::users>(object);
         m_data.setContacts(users->user_ids_);
@@ -324,7 +324,7 @@ void PurpleTdClient::getContactsResponse(uint64_t requestId, td::td_api::object_
 
 void PurpleTdClient::getChatsResponse(uint64_t requestId, td::td_api::object_ptr<td::td_api::Object> object)
 {
-    purple_debug_misc(config::pluginId, "getChats response to request %llu\n", (unsigned long long)requestId);
+    purple_debug_misc(config::pluginId, "getChats response to request %" G_GUINT64_FORMAT "\n", requestId);
     if (object && (object->get_id() == td::td_api::chats::ID)) {
         td::td_api::object_ptr<td::td_api::chats> chats = td::move_tl_object_as<td::td_api::chats>(object);
         m_data.setActiveChats(std::move(chats->chat_ids_));
@@ -353,8 +353,8 @@ void PurpleTdClient::loginCreatePrivateChatResponse(uint64_t requestId, td::td_a
 {
     if (object->get_id() == td::td_api::chat::ID) {
         td::td_api::object_ptr<td::td_api::chat> chat = td::move_tl_object_as<td::td_api::chat>(object);
-        purple_debug_misc(config::pluginId, "Requested private chat received: id %lld\n",
-                          (long long)chat->id_);
+        purple_debug_misc(config::pluginId, "Requested private chat received: id %" G_GUINT64_FORMAT "\n",
+                          chat->id_);
         // Here the "new" chat already exists in AccountData because there has just been
         // updateNewChat about this same chat. But do addChat anyway, just in case.
         m_data.addChat(std::move(chat));
@@ -371,8 +371,8 @@ void PurpleTdClient::updatePrivateChat(const td::td_api::chat &chat, const td::t
 
     PurpleBuddy *buddy = purple_find_buddy(m_account, purpleUserName);
     if (buddy == NULL) {
-        purple_debug_misc(config::pluginId, "Adding new buddy %s for chat id %lld\n",
-                            chat.title_.c_str(), (long long)chat.id_);
+        purple_debug_misc(config::pluginId, "Adding new buddy %s for chat id %" G_GUINT64_FORMAT "\n",
+                            chat.title_.c_str(), chat.id_);
         buddy = purple_buddy_new(m_account, purpleUserName, chat.title_.c_str());
         purple_blist_add_buddy(buddy, NULL, NULL, NULL);
         // If a new buddy has been added here, it means that there was updateUser with phone number.
@@ -806,8 +806,8 @@ void PurpleTdClient::onIncomingMessage(td::td_api::object_ptr<td::td_api::messag
 
     const td::td_api::chat *chat = m_data.getChat(message->chat_id_);
     if (!chat) {
-        purple_debug_warning(config::pluginId, "Received message with unknown chat id %lld\n",
-                            (long long)message->chat_id_);
+        purple_debug_warning(config::pluginId, "Received message with unknown chat id %" G_GUINT64_FORMAT "\n",
+                            message->chat_id_);
         return;
     }
 
@@ -973,13 +973,13 @@ void PurpleTdClient::handleUserChatAction(const td::td_api::updateUserChatAction
     chat = m_data.getChat(updateChatAction.chat_id_);
 
     if (!chat)
-        purple_debug_warning(config::pluginId, "Got user chat action for unknown chat %lld\n",
-                             (long long)updateChatAction.chat_id_);
+        purple_debug_warning(config::pluginId, "Got user chat action for unknown chat %" G_GUINT64_FORMAT "\n",
+                             updateChatAction.chat_id_);
     else if (chat->type_->get_id() == td::td_api::chatTypePrivate::ID) {
         const td::td_api::chatTypePrivate &privType = static_cast<const td::td_api::chatTypePrivate &>(*chat->type_);
         if (privType.user_id_ != updateChatAction.user_id_)
-            purple_debug_warning(config::pluginId, "Got user action for private chat %lld (with user %d) for another user %d\n",
-                                 (long long)updateChatAction.chat_id_, privType.user_id_,
+            purple_debug_warning(config::pluginId, "Got user action for private chat %" G_GUINT64_FORMAT " (with user %d) for another user %d\n",
+                                 updateChatAction.chat_id_, privType.user_id_,
                                  updateChatAction.user_id_);
         else if (updateChatAction.action_) {
             if (updateChatAction.action_->get_id() == td::td_api::chatActionCancel::ID) {
@@ -997,8 +997,8 @@ void PurpleTdClient::handleUserChatAction(const td::td_api::updateUserChatAction
             }
         }
     } else
-        purple_debug_misc(config::pluginId, "Ignoring user chat action for non-private chat %lld\n",
-                          (long long)updateChatAction.chat_id_);
+        purple_debug_misc(config::pluginId, "Ignoring user chat action for non-private chat %" G_GUINT64_FORMAT "\n",
+                          updateChatAction.chat_id_);
 }
 
 void PurpleTdClient::showUserChatAction(int32_t userId, bool isTyping)

--- a/transceiver.cpp
+++ b/transceiver.cpp
@@ -138,8 +138,8 @@ int TdTransceiverImpl::rxCallback(gpointer user_data)
                 callback = it->second;
                 self->m_responseHandlers.erase(it);
             } else
-                purple_debug_misc(config::pluginId, "Ignoring response to request %llu\n",
-                                  (unsigned long long)response.id);
+                purple_debug_misc(config::pluginId, "Ignoring response to request %" G_GUINT64_FORMAT "\n",
+                                  response.id);
             if (callback)
                 ((self->m_owner)->*callback)(response.id, std::move(response.object));
         }


### PR DESCRIPTION
I've spent the last couple of days compiling tdlib and tdlib-purple for windows.

Everything went 99% smoothly (other than the manual manipulation of CMakeLists.txt, since there's no pkg-config on windows), however the %lld printf() macro isn't valid on Windows

I tried to make it use the standard Priu64 however there were conflicts between the 64bit OS and compiling a 32bit dll that made this impossible, so I switched to the glib macro instead