### PR TITLE
Fix for compiling with rlottie on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ if (NOT NoLottie)
         target_include_directories(telegram-tdlib PRIVATE rlottie/inc)
     endif (NOT NoBundledLottie)
     target_link_libraries(telegram-tdlib PRIVATE rlottie)
+	target_compile_definitions(telegram-tdlib PRIVATE LOT_BUILD)
 endif (NOT NoLottie)
 
 if (NOT DEFINED SHARE_INSTALL_PREFIX)

--- a/rlottie/CMakeLists.txt
+++ b/rlottie/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 #declare target
 add_library( rlottie )
-set_target_properties( rlottie PROPERTIES DEFINE_SYMBOL LOT_BUILD )
+target_compile_definitions( rlottie PRIVATE LOT_BUILD )
 
 #declare version of the target
 set(player_version_major 0)


### PR DESCRIPTION
When LOT_BUILD is not defined, the required functions aren't marked for export, which causes the ld linking errors of:

```
CMakeFiles/telegram-tdlib.dir/tdlib-purple.cpp.obj:tdlib-purple.cpp:(.text+0x1ec0): undefined reference to `_imp___ZN7rlottie23configureModelCacheSizeEj'
CMakeFiles/telegram-tdlib.dir/sticker.cpp.obj:sticker.cpp:(.text+0xf1e): undefined reference to `_imp___ZN7rlottie9Animation12loadFromDataENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKS6_S8_b'
CMakeFiles/telegram-tdlib.dir/sticker.cpp.obj:sticker.cpp:(.text+0x1001): undefined reference to `_imp___ZNK7rlottie9Animation10totalFrameEv'
CMakeFiles/telegram-tdlib.dir/sticker.cpp.obj:sticker.cpp:(.text+0x120a): undefined reference to `_imp___ZN7rlottie7SurfaceC1EPjjjj'
CMakeFiles/telegram-tdlib.dir/sticker.cpp.obj:sticker.cpp:(.text+0x127a): undefined reference to `_imp___ZN7rlottie9Animation10renderSyncEjNS_7SurfaceEb'
CMakeFiles/telegram-tdlib.dir/sticker.cpp.obj:sticker.cpp:(.text+0x2216): undefined reference to `_imp___ZN7rlottie9AnimationD1Ev'
CMakeFiles/telegram-tdlib.dir/sticker.cpp.obj:sticker.cpp:(.text+0x2434): undefined reference to `_imp___ZN7rlottie9AnimationD1Ev'
CMakeFiles/telegram-tdlib.dir/sticker.cpp.obj:sticker.cpp:(.text.unlikely+0xb9): undefined reference to `_imp___ZN7rlottie9AnimationD1Ev'
collect2.exe: error: ld returned 1 exit status
```