### PR TITLE
Automatically build and test on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
+.travis_cache/
 *.kdev4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,78 @@
+# xenial (16.04) is so outdated that it has trouble with LTO.
+# bionic (18.04) is good, but doesn't have the package librlottie-dev
+# focal (20.04) isn't officially supported by Travis yet,
+#   but I expect that it will be supported at least until 2026.
+dist: focal
+language: cpp
+compiler:
+  - gcc
+  - clang
+env:
+# Try to be nice to the builder
+  - CMAKE_FLAGS="                                                 " INSTALL_LOCAL_LOTTIE=n
+  - CMAKE_FLAGS="-DNoWebp=1                                       " INSTALL_LOCAL_LOTTIE=n
+  - CMAKE_FLAGS="           -DNoTranslations=1                    " INSTALL_LOCAL_LOTTIE=n
+#  - CMAKE_FLAGS="-DNoWebp=1 -DNoTranslations=1                    " INSTALL_LOCAL_LOTTIE=n
+  - CMAKE_FLAGS="                              -DNoLottie=1       " INSTALL_LOCAL_LOTTIE=n
+#  - CMAKE_FLAGS="-DNoWebp=1                    -DNoLottie=1       " INSTALL_LOCAL_LOTTIE=n
+#  - CMAKE_FLAGS="           -DNoTranslations=1 -DNoLottie=1       " INSTALL_LOCAL_LOTTIE=n
+#  - CMAKE_FLAGS="-DNoWebp=1 -DNoTranslations=1 -DNoLottie=1       " INSTALL_LOCAL_LOTTIE=n
+  - CMAKE_FLAGS="                              -DNoBundledLottie=1" INSTALL_LOCAL_LOTTIE=y
+#  - CMAKE_FLAGS="-DNoWebp=1                    -DNoBundledLottie=1" INSTALL_LOCAL_LOTTIE=y
+#  - CMAKE_FLAGS="           -DNoTranslations=1 -DNoBundledLottie=1" INSTALL_LOCAL_LOTTIE=y
+  - CMAKE_FLAGS="-DNoWebp=1 -DNoTranslations=1 -DNoBundledLottie=1" INSTALL_LOCAL_LOTTIE=y
+matrix:
+# Be even nicer by excluding half of the combinations:
+  exclude:
+#    - compiler: gcc
+#      env: CMAKE_FLAGS="                                                 " INSTALL_LOCAL_LOTTIE=n
+    - compiler: clang
+      env: CMAKE_FLAGS="                                                 " INSTALL_LOCAL_LOTTIE=n
+    - compiler: gcc
+      env: CMAKE_FLAGS="-DNoWebp=1                                       " INSTALL_LOCAL_LOTTIE=n
+#    - compiler: clang
+#      env: CMAKE_FLAGS="-DNoWebp=1                                       " INSTALL_LOCAL_LOTTIE=n
+#    - compiler: gcc
+#      env: CMAKE_FLAGS="           -DNoTranslations=1                    " INSTALL_LOCAL_LOTTIE=n
+    - compiler: clang
+      env: CMAKE_FLAGS="           -DNoTranslations=1                    " INSTALL_LOCAL_LOTTIE=n
+    - compiler: gcc
+      env: CMAKE_FLAGS="                              -DNoLottie=1       " INSTALL_LOCAL_LOTTIE=n
+#    - compiler: clang
+#      env: CMAKE_FLAGS="                              -DNoLottie=1       " INSTALL_LOCAL_LOTTIE=n
+#    - compiler: gcc
+#      env: CMAKE_FLAGS="                              -DNoBundledLottie=1" INSTALL_LOCAL_LOTTIE=y
+    - compiler: clang
+      env: CMAKE_FLAGS="                              -DNoBundledLottie=1" INSTALL_LOCAL_LOTTIE=y
+    - compiler: gcc
+      env: CMAKE_FLAGS="-DNoWebp=1 -DNoTranslations=1 -DNoBundledLottie=1" INSTALL_LOCAL_LOTTIE=y
+#    - compiler: clang
+#      env: CMAKE_FLAGS="-DNoWebp=1 -DNoTranslations=1 -DNoBundledLottie=1" INSTALL_LOCAL_LOTTIE=y
+
+cache:
+  directories:
+  - .travis_cache/
+
+before_install:
+  - git submodule update --init --recursive
+  - sudo apt-get update -qq
+  - sudo apt-get install -y -qq gperf libpurple-dev libwebp-dev libgtest-dev
+  # TODO: php is not strictly necessary (I don't have php installed), but it apparently is on Travis?!
+  # Ubbuntu Bionic (php on image): works
+  #     https://travis-ci.com/github/BenWiederhake/tdlib-purple/jobs/358165125#L1186
+  # Ubuntu Focal (no php on image): fails
+  #     https://travis-ci.com/github/BenWiederhake/tdlib-purple/builds/174538475#L799
+  # Ubuntu Focal, manually install php: works
+  #     https://travis-ci.com/github/BenWiederhake/tdlib-purple/builds/174539831#L907
+  - sudo apt-get install -y -qq php
+  - if [ "x${INSTALL_LOCAL_LOTTIE}" = "xy" ] ; then sudo apt-get install -y -qq librlottie-dev ; fi
+
+script:
+  - ./build_td.sh
+  - cd build
+# TODO: Try out building with the voip library?
+  - cmake -DTd_DIR=.travis_cache/td_destdir/usr/local/lib/cmake/Td -DNoVoip=1 ..
+  - make -j2 VERBOSE=1
+  - make -j2 tests
+  - make run-tests
+  - make install DESTDIR=tdprpl_destdir install

--- a/build_td.sh
+++ b/build_td.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+set -ex
+cd "$(dirname $0)"
+
+# == CONFIGURATION ==
+# The tag/version of tdlib that we want to check out.
+TAG="v1.6.0"
+# Change this if you want to invalidate the Travis cache and force a rebuild.
+MARK="1"
+# Just in case we want to change it.
+CACHE_DIR=".travis_cache"
+
+# == SETUP ==
+CACHE_ID="${TAG}_m${MARK}"
+mkdir -p "${CACHE_DIR}"
+mkdir -p build
+
+# == CHECK CACHE ==
+echo "${CACHE_ID}" > "${CACHE_DIR}/cache_id_expected.txt"
+rm -rf td_destdir # Just in case
+if [ -r "${CACHE_DIR}/cache_id_actual.txt" ] && [ -x "${CACHE_DIR}/td_destdir" ] && diff -q "${CACHE_DIR}/cache_id_actual.txt" "${CACHE_DIR}/cache_id_expected.txt"
+then
+    rm "${CACHE_DIR}/cache_id_expected.txt"
+    echo "Using existing td_destdir for tag ${TAG}, mark ${MARK}."
+    echo "Great success!"
+    exit 0
+else
+    echo "Cache not usable:"
+    echo "    expected: ${CACHE_ID}"
+    echo "    actual: $(cat "${CACHE_DIR}/cache_id_actual.txt" 2> /dev/null || echo NONE)"
+    rm -rf "${CACHE_DIR}/cache_id_actual.txt" "${CACHE_DIR}/td_destdir"
+fi
+
+# == BUILD TDLIB ==
+cd build
+    rm -rf td_repo # Just in case
+    git clone -q -c advice.detachedHead=false -b "${TAG}" --depth 1 https://github.com/tdlib/td.git td_repo
+    cd td_repo
+        mkdir build
+        cd build
+            cmake .. -DCMAKE_BUILD_TYPE=Release
+            make install -j2 DESTDIR="../../../${CACHE_DIR}/td_destdir"
+        cd ..
+    cd ..
+cd ..
+
+# == CREATE CACHE ==
+mv "${CACHE_DIR}/cache_id_expected.txt" "${CACHE_DIR}/cache_id_actual.txt"
+
+# Now you can build tdlib-purple using
+# `cmake -DTd_DIR=.travis_cache/td_destdir/usr/local/lib/cmake/Td ..`

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,6 +33,10 @@ add_executable(tests EXCLUDE_FROM_ALL
     ../call.cpp
 )
 
+# libpurple uses the deprecated glib-type `GParameter` and the deprecated glib-macro `G_CONST_RETURN`, which
+# spams the console with useless warnings that we can do nothing about.
+target_compile_definitions(tests PRIVATE GLIB_DISABLE_DEPRECATION_WARNINGS)
+
 set_property(TARGET tests PROPERTY CXX_STANDARD 14)
 target_include_directories(tests PRIVATE ${CMAKE_SOURCE_DIR})
 target_link_libraries(tests PRIVATE gtest fmt::fmt Td::TdStatic ${GLIB_LIBRARIES})


### PR DESCRIPTION
The build matrix is currently restricted to `NoVoip=1`, but I hope that's good enough for a start.

`td` itself will be cached on Travis, so only the first two builds will take "long", and again each time we update the td version.

Let me know what you think! :)