### PR TITLE
Add notes for translators

### DIFF
--- a/call.cpp
+++ b/call.cpp
@@ -24,7 +24,9 @@ bool initiateCall(int32_t userId, TdAccountData &account, TdTransceiver &transce
         callRequest->protocol_ = getCallProtocol();
         transceiver.sendQuery(std::move(callRequest), nullptr);
     } else
+        // TRANSLATOR: Dialog title of an error message.
         purple_notify_warning(account.purpleAccount, _("Voice call"),
+                              // TRANSLATOR: Dialog content of an error message.
                               _("Cannot start new call, already in another call"), NULL);
 #endif
 
@@ -134,7 +136,9 @@ static bool activateCall(const td::td_api::call &call, const std::string &buddyN
     if (!buddyName.empty()) {
         // For an outgoing call, "type /hangup to terminate" has already been shown when the call
         // was initiated
+        // TRANSLATOR: In-chat status message
         const char *message = call.is_outgoing_ ? _("Call active") :
+                                                  // TRANSLATOR: In-chat status message
                                                   _("Call active, type /hangup to terminate");
         showMessageTextIm(account, buddyName.c_str(), NULL, message,
                           time(NULL), PURPLE_MESSAGE_SYSTEM);
@@ -163,6 +167,7 @@ static void notifyCallError(const td::td_api::callStateError &error, const std::
     else
         // Unlikely message not worth translating
         message = "unknown error";
+    // TRANSLATOR: In-chat error message, argument is text
     message = formatMessage(_("Call failed: {}"), message);
     if (!buddyName.empty())
         showMessageTextIm(account, buddyName.c_str(), NULL, message.c_str(),
@@ -186,6 +191,7 @@ void updateCall(const td::td_api::call &call, TdAccountData &account, TdTranscei
         if (call.state_ && (call.state_->get_id() == td::td_api::callStatePending::ID)) {
             if (!buddyName.empty())
                 showMessageTextIm(account, buddyName.c_str(), NULL,
+                                  // TRANSLATOR: In-chat error message
                                   _("Received incoming call, but calls are not supported"),
                                   time(NULL), PURPLE_MESSAGE_SYSTEM);
 
@@ -199,6 +205,7 @@ void updateCall(const td::td_api::call &call, TdAccountData &account, TdTranscei
     if (!call.is_outgoing_ && (call.state_->get_id() == td::td_api::callStatePending::ID)) {
         if (!account.hasActiveCall()) {
             account.setActiveCall(call.id_);
+            // TRANSLATOR: Dialog content, user will have the options "OK" and "Cancel".
             std::string message = formatMessage(_("{} wishes to start a call with you."),
                                                 account.getDisplayName(call.user_id_));
             CallRequestData *request = new CallRequestData;
@@ -206,13 +213,18 @@ void updateCall(const td::td_api::call &call, TdAccountData &account, TdTranscei
             request->transceiver = &transceiver;
             request->account = &account;
             purple_request_action(purple_account_get_connection(account.purpleAccount),
+                                  // TRANSLATOR: Dialog title, asking about an incoming telephone call (OK/Cancel)
                                   _("Voice call"), message.c_str(), NULL,
                                   PURPLE_DEFAULT_ACTION_NONE,
                                   account.purpleAccount, !buddyName.empty() ? buddyName.c_str() : NULL, NULL,
-                                  request, 2, _("_OK"), acceptCallCb, _("_Cancel"), discardCallCb);
+                                  // TRANSLATOR: Dialog option, regarding a phone call; the alternative is "_Cancel"
+                                  request, 2, _("_OK"), acceptCallCb,
+                                  // TRANSLATOR: Dialog option, regarding a phone call; the alternative is "_OK"
+                                  _("_Cancel"), discardCallCb);
         } else if (call.id_ != account.getActiveCallId()) {
             if (!buddyName.empty())
                 showMessageTextIm(account, buddyName.c_str(), NULL,
+                                // TRANSLATOR: In-chat error message
                                 _("Received incoming call while already in another call"),
                                 time(NULL), PURPLE_MESSAGE_SYSTEM);
 
@@ -223,6 +235,7 @@ void updateCall(const td::td_api::call &call, TdAccountData &account, TdTranscei
             account.setActiveCall(call.id_);
             if (!buddyName.empty())
                 showMessageTextIm(account, buddyName.c_str(), NULL,
+                                // TRANSLATOR: In-chat status message
                                 _("Call pending, type /hangup to terminate"),
                                 time(NULL), PURPLE_MESSAGE_SYSTEM);
         } else if (call.id_ != account.getActiveCallId()) {
@@ -264,21 +277,28 @@ void showCallMessage(const td::td_api::chat &chat, const TgMessageInfo &message,
     if (callEnded.discard_reason_)
         switch (callEnded.discard_reason_->get_id()) {
             case td::td_api::callDiscardReasonMissed::ID:
+                // TRANSLATOR: In-line reason for an ended call; appears after a colon (':')
                 notification = _("call missed");
                 break;
             case td::td_api::callDiscardReasonDeclined::ID:
+                // TRANSLATOR: In-line reason for an ended call; appears after a colon (':')
                 notification = _("declined by peer");
                 break;
             case td::td_api::callDiscardReasonDisconnected::ID:
+                // TRANSLATOR: In-line reason for an ended call; appears after a colon (':')
                 notification = _("users disconnected");
                 break;
             case td::td_api::callDiscardReasonHungUp::ID:
+                // TRANSLATOR: In-line reason for an ended call; appears after a colon (':')
                 notification = _("hung up");
                 break;
         }
-    if (notification.empty())
+    if (notification.empty()) {
+        // TRANSLATOR: In-line reason for an ended call; appears after a colon (':')
         notification = _("reason unknown");
+    }
 
+    // TRANSLATOR: In-chat message, arguments will be a number and a few words (like "hung up")
     notification = formatMessage(_("Call ended ({} seconds): {}"), {std::to_string(callEnded.duration_), notification});
     showMessageText(account, chat, message, NULL, notification.c_str());
 }

--- a/client-utils.cpp
+++ b/client-utils.cpp
@@ -461,7 +461,7 @@ static std::string quoteMessage(const td::td_api::message *message, TdAccountDat
         originalName = account.getDisplayName(*originalAuthor);
     else {
         // TRANSLATOR: In-line placeholder if the original author of a quote is unknown. Is at the beginning of the line if and only if you make it so, see "<b>&bt {} wrote:"...
-        originalName = _("unknown user");
+        originalName = _("Unknown user");
     }
 
     std::string text;
@@ -1032,7 +1032,9 @@ void updateSecretChat(td::td_api::object_ptr<td::td_api::secretChat> secretChat,
     if (user)
         userDescription = '\'' + account.getDisplayName(*user) + '\'';
     else {
-        // TRANSLATOR: Place-holder for an unknown username
+        // TRANSLATOR: Place-holder for an unknown username. Is at the beginning of the line if and
+        // only if you make it so, see "Rejected secret chat with {}", "Rejected secret chat with {}",
+        // and "Accept secret chat with {} on…".
         userDescription = _("(unknown user)");
     }
 

--- a/client-utils.cpp
+++ b/client-utils.cpp
@@ -14,6 +14,7 @@ enum {
 
 const char *errorCodeMessage()
 {
+    // TRANSLATOR: In-line error message, appears after a colon (':'), arguments will be a number and some error text from Telegram
     return _("code {} ({})");
 }
 
@@ -244,6 +245,7 @@ void updatePrivateChat(TdAccountData &account, const td::td_api::chat &chat, con
                                                                             account.purpleAccount);
         if (oldConv) {
             purple_conv_im_write(purple_conversation_get_im_data(oldConv), nullptr,
+                                 // TRANSLATOR: In-chat status update
                                  _("Future messages in this conversation will be shown in a different tab"),
                                  PURPLE_MESSAGE_SYSTEM, time(NULL));
         }
@@ -457,13 +459,16 @@ static std::string quoteMessage(const td::td_api::message *message, TdAccountDat
     std::string originalName;
     if (originalAuthor)
         originalName = account.getDisplayName(*originalAuthor);
-    else
+    else {
+        // TRANSLATOR: In-line placeholder if the original author of a quote is unknown. Is at the beginning of the line if and only if you make it so, see "<b>&bt {} wrote:"...
         originalName = _("unknown user");
+    }
 
     std::string text;
-    if (!message || !message->content_)
+    if (!message || !message->content_) {
+        // TRANSLATOR: In-line placeholder when something unknown is being replied to.
         text = _("[message unavailable]");
-    else switch (message->content_->get_id()) {
+    } else switch (message->content_->get_id()) {
         case td::td_api::messageText::ID: {
             const td::td_api::messageText &messageText = static_cast<const td::td_api::messageText &>(*message->content_);
             if (messageText.text_)
@@ -474,6 +479,7 @@ static std::string quoteMessage(const td::td_api::message *message, TdAccountDat
         }
         case td::td_api::messagePhoto::ID: {
             const td::td_api::messagePhoto &photo = static_cast<const td::td_api::messagePhoto &>(*message->content_);
+            // TRANSLATOR: In-line placeholder when a photo is being replied to.
             text = _("[photo]");
             if (photo.caption_)
                 text += " " + photo.caption_->text_;
@@ -481,35 +487,44 @@ static std::string quoteMessage(const td::td_api::message *message, TdAccountDat
         }
         case td::td_api::messageDocument::ID: {
             const td::td_api::messageDocument &document = static_cast<const td::td_api::messageDocument &>(*message->content_);
-            if (document.document_)
+            if (document.document_) {
+                // TRANSLATOR: In-line placeholder when a file is being replied to. Arguments will be the file name and MIME type (e.g. "application/gzip")
                 text = formatMessage(_("[file: {} ({})"), {document.document_->file_name_,
                                                            document.document_->mime_type_});
-            else
+            } else {
+                // TRANSLATOR: In-line placeholder when an unknown file is being replied to.
                 text = _("[file]");
+            }
             if (document.caption_)
                 text += " " + document.caption_->text_;
             break;
         }
         case td::td_api::messageVideo::ID: {
             const td::td_api::messageVideo &video = static_cast<const td::td_api::messageVideo &>(*message->content_);
-            if (video.video_)
+            if (video.video_) {
+                // TRANSLATOR: In-line placeholder when a video is being replied to. Argument will be the file name.
                 text = formatMessage(_("[video: {}]"), video.video_->file_name_);
-            else
+            } else {
+                // TRANSLATOR: In-line placeholder when an unknown video/gif is being replied to.
                 text = _("[video]");
+            }
             if (video.caption_)
                 text += " " + video.caption_->text_;
             break;
         }
         case td::td_api::messageSticker::ID:
+            // TRANSLATOR: In-line placeholder when a sticker is being replied to.
             text = _("[sticker]");
             break;
         default:
+            // TRANSLATOR: In-line placeholder when a message is being replied to, and the message has a weird type.
             text = formatMessage(_("[message type {}]"), messageTypeToString(*message->content_));
     }
 
     for (unsigned i = 0; i < text.size(); i++)
         if (text[i] == '\n') text[i] = ' ';
 
+    // TRANSLATOR: In-chat notification of a reply. Arguments will be username and the original text or description thereof. Please preserve the HTML.
     return formatMessage(_("<b>&gt; {} wrote:</b>\n&gt; {}"), {originalName, text});
 }
 
@@ -526,6 +541,7 @@ void showMessageText(TdAccountData &account, const td::td_api::chat &chat, const
     if (!message.forwardedFrom.empty()) {
         if (!newText.empty())
             newText += "\n";
+        // TRANSLATOR: In-chat notification of forward. Argument will be a username. Please preserve the HTML.
         newText += formatMessage(_("<b>Forwarded from {}:</b>"), message.forwardedFrom);
     }
     if (text) {
@@ -578,9 +594,10 @@ std::string getSenderPurpleName(const td::td_api::chat &chat, const td::td_api::
             return account.getDisplayName(message.sender_user_id_);
         else if (!message.author_signature_.empty())
             return message.author_signature_;
-        else if (message.is_channel_post_)
+        else if (message.is_channel_post_) {
+            // TRANSLATOR: The "sender" of a message that was "sent" by the channel itself. Will be used like a username.
             return _("Channel post");
-        else if (message.forward_info_ && message.forward_info_->origin_)
+        } else if (message.forward_info_ && message.forward_info_->origin_)
             switch (message.forward_info_->origin_->get_id()) {
             case td::td_api::messageForwardOriginUser::ID:
                 return account.getDisplayName(static_cast<const td::td_api::messageForwardOriginUser &>(*message.forward_info_->origin_).sender_user_id_);
@@ -957,6 +974,7 @@ void notifySendFailed(const td::td_api::updateMessageSendFailed &sendFailed, TdA
             messageInfo.outgoing = true;
             std::string errorMessage = formatMessage(errorCodeMessage(), {std::to_string(sendFailed.error_code_),
                                                      sendFailed.error_message_});
+            // TRANSLATOR: In-chat error message, argument will be text.
             errorMessage = formatMessage(_("Failed to send message: {}"), errorMessage);
             showMessageText(account, *chat, messageInfo, NULL, errorMessage.c_str());
         }
@@ -972,9 +990,13 @@ static void secretChatNotSupported(int32_t secretChatId, const std::string &user
                                    TdTransceiver &transceiver, PurpleAccount *purpleAccount)
 {
     closeSecretChat(secretChatId, transceiver);
+    // TRANSLATOR: Dialog content, argument will be a username
     std::string message = formatMessage(_("Rejected secret chat with {}"), userDescription);
     purple_notify_info(purple_account_get_connection(purpleAccount),
-                        _("Secret chat"), message.c_str(), "Secret chats not supported");
+                        // TRANSLATOR: Dialog title
+                        _("Secret chat"), message.c_str(),
+                        // TRANSLATOR: Dialog secondary content; used as a justification for a failing chat.
+                        _("Secret chats not supported"));
 }
 
 struct SecretChatInfo {
@@ -1009,8 +1031,10 @@ void updateSecretChat(td::td_api::object_ptr<td::td_api::secretChat> secretChat,
     std::string userDescription;
     if (user)
         userDescription = '\'' + account.getDisplayName(*user) + '\'';
-    else
+    else {
+        // TRANSLATOR: Place-holder for an unknown username
         userDescription = _("(unknown user)");
+    }
 
     if (!isExisting) {
         const char *secretChatHandling = purple_account_get_string(account.purpleAccount,
@@ -1018,20 +1042,29 @@ void updateSecretChat(td::td_api::object_ptr<td::td_api::secretChat> secretChat,
                                                                    AccountOptions::AcceptSecretChatsDefault);
         if (!strcmp(secretChatHandling, AccountOptions::AcceptSecretChatsNever)) {
             closeSecretChat(secretChatId, transceiver);
+            // TRANSLATOR: Dialog content, argument will be a username
             std::string message = formatMessage(_("Rejected secret chat with {}"), userDescription);
             purple_notify_info(purple_account_get_connection(account.purpleAccount),
+                               // TRANSLATOR: Dialog title
                                _("Secret chat"), message.c_str(), NULL);
         } else if (!strcmp(secretChatHandling, AccountOptions::AcceptSecretChatsAlways))
             secretChatNotSupported(secretChatId, userDescription, transceiver, account.purpleAccount);
         else {
+            // TRANSLATOR: Dialog content, argument will be a username, options will be "_Accept" and "_Cancel".
             std::string message = formatMessage(_("Accept secret chat with {} on this device?"), userDescription);
             SecretChatInfo *data = new SecretChatInfo{secretChatId, userDescription, &transceiver, account.purpleAccount};
             purple_request_action(purple_account_get_connection(account.purpleAccount),
-                _("Secret chat"), message.c_str(), _("Secret chats can only have one "
+                // TRANSLATOR: Dialog title
+                _("Secret chat"), message.c_str(),
+                // TRANSLATOR: Dialog secondary content. Options will be "_Accept" and "_Cancel".
+                _("Secret chats can only have one "
                 "end point. If you accept a secret chat on this device, its messages will not be available anywhere "
                 "else. If you decline, you can still accept the chat on other devices."),
                 0, account.purpleAccount, NULL, NULL, data, 2,
-                _("_Accept"), acceptSecretChatCb, _("_Cancel"), discardSecretChatCb);
+                // TRANSLATOR: Dialog option, regarding a secret chat; the alternative is "_Cancel"
+                _("_Accept"), acceptSecretChatCb,
+                // TRANSLATOR: Dialog option, regarding a secret chat; the alternative is "_Accept"
+                _("_Cancel"), discardSecretChatCb);
         }
     }
 }

--- a/file-transfer.cpp
+++ b/file-transfer.cpp
@@ -455,6 +455,7 @@ std::string makeDocumentDescription(const td::td_api::voiceNote *document)
     if (!document)
         // Unlikely error message not worth translating
         return "faulty voice note";
+    // TRANSLATOR: In-line document type. Argument will be a mime type.
     return formatMessage(_("voice note [{}]"), document->mime_type_);
 }
 
@@ -463,18 +464,22 @@ std::string makeDocumentDescription(const td::td_api::videoNote *document)
     if (!document)
         // Unlikely error message not worth translating
         return "faulty voice note";
+    // TRANSLATOR: In-line document type. Argument will be a number.
     return formatMessage(_("video note [{} s]"), document->duration_);
 }
 
 std::string getFileName(const td::td_api::voiceNote* document)
 {
     td::Client::Response resp = td::Client::execute({0, td::td_api::make_object<td::td_api::getFileExtension>(document->mime_type_)});
-    if (resp.object && (resp.object->get_id() == td::td_api::text::ID))
+    if (resp.object && (resp.object->get_id() == td::td_api::text::ID)) {
+        // TRANSLATOR: Filename. Keep it short, and as few special characters as possible.
         return std::string(_("voiceNote")) + '.' + static_cast<const td::td_api::text &>(*resp.object).text_;
+    }
     return _("voiceNote");
 }
 
 std::string getFileName(const td::td_api::videoNote *document)
 {
+    // TRANSLATOR: Filename. Keep it short, and as few special characters as possible.
     return std::string(_("videoNote")) + ".avi";
 }

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,7 +1,9 @@
 # List of source files containing translatable strings.
 # Only some of them are currently used, but I want to avoid headaches down the road.
 account-data.cpp
+call.cpp
 client-utils.cpp
+file-transfer.cpp
 format.cpp
 purple-info.cpp
 sticker.cpp

--- a/purple-info.cpp
+++ b/purple-info.cpp
@@ -19,24 +19,28 @@ GList *getChatJoinInfo()
     // First entry is the internal chat name used to look up conversations
     struct proto_chat_entry *pce;
     pce = g_new0 (struct proto_chat_entry, 1);
+    // TRANSLATOR: Info item *and* dialog item.
     pce->label = _("Chat ID (don't change):");
     pce->identifier = chatNameComponent;
     pce->required = FALSE;
     GList *info = g_list_append (NULL, pce);
 
     pce = g_new0 (struct proto_chat_entry, 1);
+    // TRANSLATOR: Info item *and* dialog item.
     pce->label = _("Join URL or name (empty if creating new):");
     pce->identifier = joinStringKey;
     pce->required = FALSE;
     info = g_list_append (info, pce);
 
     pce = g_new0 (struct proto_chat_entry, 1);
+    // TRANSLATOR: Info item *and* dialog item.
     pce->label = _("Group name (if creating a group):");
     pce->identifier = nameKey;
     pce->required = FALSE;
     info = g_list_append (info, pce);
 
     pce = g_new0 (struct proto_chat_entry, 1);
+    // TRANSLATOR: Info item *and* dialog item.
     pce->label = _("Group to create: 1=small 2=big 3=channel");
     pce->identifier = typeKey;
     pce->required = FALSE;
@@ -108,7 +112,9 @@ unsigned getAutoDownloadLimitKb(PurpleAccount *account)
     float dlLimit = strtof(dlLimitStr.c_str(), &endptr);
 
     if (*endptr != '\0') {
+        // TRANSLATOR: Buddy-window error message, argument will be a "number".
         std::string message = formatMessage(_("Invalid auto-download limit '{}', resetting to default"), dlLimitStr);
+        // TRANSLATOR: Title of a buddy-window error message
         purple_notify_warning(account, _("Download limit"), message.c_str(), NULL);
         purple_account_set_string(account, AccountOptions::AutoDownloadLimit,
                                   AccountOptions::AutoDownloadLimitDefault);

--- a/tdlib-purple.cpp
+++ b/tdlib-purple.cpp
@@ -31,6 +31,7 @@ static const char *getLastOnline(const td::td_api::UserStatus &status)
 {
     switch (status.get_id()) {
         case td::td_api::userStatusOnline::ID:
+            // TRANSLATOR: Buddy infobox, value for "last online"
             return _("now");
         case td::td_api::userStatusOffline::ID: {
             const td::td_api::userStatusOffline &offline = static_cast<const td::td_api::userStatusOffline &>(status);
@@ -38,10 +39,13 @@ static const char *getLastOnline(const td::td_api::UserStatus &status)
             return ctime(&timestamp);
         }
         case td::td_api::userStatusRecently::ID:
+            // TRANSLATOR: Buddy infobox, value for "last online"
             return _("recently");
         case td::td_api::userStatusLastWeek::ID:
+            // TRANSLATOR: Buddy infobox, value for "last online"
             return _("last week");
         case td::td_api::userStatusLastMonth::ID:
+            // TRANSLATOR: Buddy infobox, value for "last online"
             return _("last month");
     }
 
@@ -58,8 +62,10 @@ static void tgprpl_tooltip_text (PurpleBuddy *buddy, PurpleNotifyUserInfo *info,
 
     if ((users.size() == 1) && users[0]->status_) {
         const char *lastOnline = getLastOnline(*users[0]->status_);
-        if (lastOnline && *lastOnline)
+        if (lastOnline && *lastOnline) {
+            // TRANSLATOR: Buddy infobox, key
             purple_notify_user_info_add_pair(info, _("Last online"), lastOnline);
+        }
     }
 }
 
@@ -120,17 +126,29 @@ static void leaveGroup(PurpleBlistNode *node, gpointer data)
         RequestData *request   = new RequestData(account);
         request->stringData = chatName ? chatName : "";
 
-        if (tdClient->getBasicGroupMembership(chatName) == BasicGroupMembership::Creator)
+        if (tdClient->getBasicGroupMembership(chatName) == BasicGroupMembership::Creator) {
+            // TRANSLATOR: Owning group deletion dialog, title
             purple_request_action(purple_account_get_connection(account), _("Leaving group"),
+                                  // TRANSLATOR: Owning group deletion dialog, primary content
                                   _("Confirm deleting group"),
+                                  // TRANSLATOR: Owning group deletion dialog, secondary content
                                   _("Leaving basic group you created will delete the group. Continue?"),
                                   0, account, NULL, NULL, request, 2,
-                                  _("_Yes"), leaveGroupConfirm, _("_No"), cancelRequest);
-        else
+                                  // TRANSLATOR: Owning group deletion dialog, alternative is "_No"
+                                  _("_Yes"), leaveGroupConfirm,
+                                  // TRANSLATOR: Owning group deletion dialog, alternative is "_Yes"
+                                  _("_No"), cancelRequest);
+        } else {
+            // TRANSLATOR: Group leave dialog, title
             purple_request_action(purple_account_get_connection(account), _("Leaving group"),
+                                  // TRANSLATOR: Group leave dialog, content
                                   _("Leave the group?"), NULL,
                                   0, account, NULL, NULL, request, 2,
-                                  _("_Yes"), leaveGroupConfirm, _("_No"), cancelRequest);
+                                  // TRANSLATOR: Group leave dialog, alternative is "_No"
+                                  _("_Yes"), leaveGroupConfirm,
+                                  // TRANSLATOR: Group leave dialog, alternative is "_Yes"
+                                  _("_No"), cancelRequest);
+        }
     }
 }
 
@@ -145,16 +163,23 @@ static void deleteGroup(PurpleBlistNode *node, gpointer data)
     if (tdClient) {
         const char  *chatName  = getChatName(purple_chat_get_components(chat));
 
-        if (tdClient->getBasicGroupMembership(chatName) == BasicGroupMembership::NonCreator)
-            purple_notify_error(account, _("Error"), _("Cannot delete group"),
-                                _("Cannot delete basic group created by someone else"));
-        else {
+        if (tdClient->getBasicGroupMembership(chatName) == BasicGroupMembership::NonCreator) {
+            // TRANSLATOR: Group deletion error dialog, title
+            purple_notify_error(account, _("Cannot delete group"),
+                                // TRANSLATOR: Group deletion error dialog, content
+                                _("Cannot delete basic group created by someone else"), NULL);
+        } else {
             RequestData *request = new RequestData(account);
             request->stringData = chatName ? chatName : "";
+            // TRANSLATOR: Group deletion confirmation dialog, title
             purple_request_action(purple_account_get_connection(account), _("Deleting group"),
+                                  // TRANSLATOR: Group deletion confirmation dialog, content
                                   _("Delete the group?"), NULL,
                                   0, account, NULL, NULL, request, 2,
-                                  _("_Yes"), deleteGroupConfirm, _("_No"), cancelRequest);
+                                  // TRANSLATOR: Group deletion dialog, alternative is "_No"
+                                  _("_Yes"), deleteGroupConfirm,
+                                  // TRANSLATOR: Group deletion dialog, alternative is "_Yes"
+                                  _("_No"), cancelRequest);
         }
     }
 }
@@ -181,16 +206,19 @@ static GList* tgprpl_blist_node_menu (PurpleBlistNode *node)
             return menu;
 
         PurpleMenuAction* action;
+        // TRANSLATOR: Group menu action item
         action = purple_menu_action_new(_("Leave group"),
                                         PURPLE_CALLBACK(leaveGroup),
                                         NULL, NULL);
         menu = g_list_append(menu, action);
 
+        // TRANSLATOR: Group menu action item
         action = purple_menu_action_new(_("Delete group"),
                                         PURPLE_CALLBACK(deleteGroup),
                                         NULL, NULL);
         menu = g_list_append(menu, action);
 
+        // TRANSLATOR: Group menu action item
         action = purple_menu_action_new(_("Show invite link"),
                                         PURPLE_CALLBACK(showInviteLink),
                                         NULL, NULL);
@@ -262,25 +290,36 @@ static void tgprpl_info_show (PurpleConnection *gc, const char *who)
     tdClient->getUsers(who, users);
 
     PurpleNotifyUserInfo *info = purple_notify_user_info_new();
-    if (users.empty())
+    if (users.empty()) {
+        // TRANSLATOR: Buddy infobox, error
         purple_notify_user_info_add_pair(info, _("User not found"), NULL);
+    }
 
     for (const td::td_api::user *user: users) {
         if (purple_notify_user_info_get_entries(info))
             purple_notify_user_info_add_section_break(info);
 
+        // TRANSLATOR: Buddy infobox, key
         purple_notify_user_info_add_pair(info, _("First name"), user->first_name_.c_str());
+        // TRANSLATOR: Buddy infobox, key
         purple_notify_user_info_add_pair(info, _("Last name"), user->last_name_.c_str());
-        if (!user->username_.empty())
+        if (!user->username_.empty()) {
+            // TRANSLATOR: Buddy infobox, key
             purple_notify_user_info_add_pair(info, _("Username"), user->username_.c_str());
-        if (!user->phone_number_.empty())
+        }
+        if (!user->phone_number_.empty()) {
+            // TRANSLATOR: Buddy infobox, key
             purple_notify_user_info_add_pair(info, _("Phone number"), user->phone_number_.c_str());
+        }
         if (user->status_) {
             const char *lastOnline = getLastOnline(*user->status_);
-            if (lastOnline && *lastOnline)
+            if (lastOnline && *lastOnline) {
+                // TRANSLATOR: Buddy infobox, key
                 purple_notify_user_info_add_pair(info, _("Last online"), lastOnline);
+            }
         }
         std::string username = getPurpleBuddyName(*user);
+        // TRANSLATOR: Buddy infobox, key
         purple_notify_user_info_add_pair(info, _("Internal id"), username.c_str());
     }
 
@@ -324,8 +363,11 @@ static void tgprpl_request_delete_contact (PurpleConnection *gc, PurpleBuddy *bu
     RequestData *data = new RequestData(purple_connection_get_account(gc));
     data->stringData = purple_buddy_get_name(buddy);
 
-//     purple_request_yes_no(gc, _("Remove contact"), _("Remove contact"),
+    // TRANSLATOR: Buddy deletion confirmation, title
+//     purple_request_yes_no(gc, _("Remove contact"),
+//                           // TRANSLATOR: Buddy deletion confirmation, content
 //                           _("Remove from global contact list and delete chat history from the server?\n"),
+//                           NULL,
 //                           0, purple_connection_get_account(gc), purple_buddy_get_name(buddy),
 //                           NULL, data, request_delete_contact_on_server_yes,
 //                           cancelRequest);
@@ -383,8 +425,10 @@ static void requestCreateBasicGroup(PurpleConnection *gc, const char *name)
     // the user to specify at least one other one.
     PurpleRequestFields* fields = purple_request_fields_new ();
     PurpleRequestFieldGroup* group = purple_request_field_group_new (
+        // TRANSLATOR: Group creation dialog, secondary content
         _("Invite at least one additional user by specifying their full name (autocompletion available)."));
 
+    // TRANSLATOR: Group creation dialog, label
     PurpleRequestField *field = purple_request_field_string_new ("user1", _("Username"), NULL, FALSE);
     purple_request_field_set_type_hint (field, "screenname");
     purple_request_field_group_add_field (group, field);
@@ -401,8 +445,14 @@ static void requestCreateBasicGroup(PurpleConnection *gc, const char *name)
 
     RequestData *data = new RequestData(purple_connection_get_account(gc));
     data->stringData = name;
-    purple_request_fields (gc, _("Create group chat"), _("Invite users"), NULL, fields, _("OK"),
-                           G_CALLBACK(create_group_chat_cb), _("Cancel"), G_CALLBACK(cancelRequest),
+    // TRANSLATOR: Group creation dialog, title
+    purple_request_fields (gc, _("Create group chat"),
+                           // TRANSLATOR: Group creation dialog, primary content
+                           _("Invite users"), NULL, fields,
+                           // TRANSLATOR: Group creation dialog, alternative is "Cancel"
+                           _("OK"), G_CALLBACK(create_group_chat_cb),
+                           // TRANSLATOR: Group creation dialog, alternative is "OK"
+                           _("Cancel"), G_CALLBACK(cancelRequest),
                            purple_connection_get_account(gc), NULL, NULL, data);
 }
 
@@ -426,10 +476,13 @@ static void tgprpl_chat_join (PurpleConnection *gc, GHashTable *data)
             if (!name.empty())
                 tdClient->joinChatByGroupName(joinString, name.c_str());
             else {
+                // TRANSLATOR: Join error dialog, secondary content. all five arguments are URLs. "name" should be part of the URL.
                 std::string extraMessage = formatMessage(_("Invite link must start with {}, {} or {}. Public group link must be {}name or {}name."),
                                                          {invitePrefixes[0], invitePrefixes[1], invitePrefixes[2],
                                                          groupLinkPrefixes[0], groupLinkPrefixes[1]});
+                // TRANSLATOR: Join error dialog, title
                 purple_notify_error(gc, _("Failed to join chat"),
+                                    // TRANSLATOR: Join error dialog, primary content
                                     _("Must be invite link, public group link or group name"),
                                     extraMessage.c_str());
                 purple_serv_got_join_chat_failed (gc, data);
@@ -446,7 +499,10 @@ static void tgprpl_chat_join (PurpleConnection *gc, GHashTable *data)
             else
                 tdClient->createGroup(groupName, groupType, {});
         } else {
-            purple_notify_error(gc, _("Failed to join chat"), _("Please enter group name and valid type"), NULL);
+            // TRANSLATOR: Join error dialog, title
+            purple_notify_error(gc, _("Failed to join chat"),
+                                // TRANSLATOR: Join error dialog, primary content
+                                _("Please enter group name and valid type"), NULL);
             purple_serv_got_join_chat_failed (gc, data);
         }
     }
@@ -604,6 +660,7 @@ static GHashTable *tgprpl_get_account_text_table (PurpleAccount *pa)
     GHashTable *HT;
     HT = g_hash_table_new (g_str_hash, g_str_equal);
     static char label[] = "login_label";
+    // TRANSLATOR: Account creation, telephone hint. Keep it short!
     g_hash_table_insert(HT, label, _("phone no. (+ country prefix)"));
     return HT;
 }
@@ -762,11 +819,13 @@ static gboolean tgprpl_load (PurplePlugin *plugin)
     purple_cmd_register("kick", "s", PURPLE_CMD_P_PLUGIN,
                         (PurpleCmdFlag)(PURPLE_CMD_FLAG_CHAT | PURPLE_CMD_FLAG_PRPL_ONLY),
                         config::pluginId, tgprpl_cmd_kick,
+                        // TRANSLATOR: Command description, the initial "kick <user>" must remain verbatim!
                         _("kick <user>: Kick a user from the room using name or internal id"), NULL);
 
     purple_cmd_register("hangup", "", PURPLE_CMD_P_PLUGIN,
                         (PurpleCmdFlag)(PURPLE_CMD_FLAG_IM | PURPLE_CMD_FLAG_PRPL_ONLY),
                         config::pluginId, hangupCommand,
+                        // TRANSLATOR: Command description, the initial "hangup <user>" must remain verbatim!
                         _("hangup: Terminate any active call (with any user)"), NULL);
 
     return TRUE;
@@ -786,17 +845,20 @@ static gboolean tdlibFatalErrorHandler(void *data)
 {
     char *message = static_cast<char *>(data);
     const char *dbMessage =
+        // TRANSLATOR: Tdlib crash dialog, secondary content. Argument is a filesystem path. Please keep the space after it!
         _("The error may be caused by corrupt account data. "
           "If this is the case, it could be fixed by removing account data under {} . "
           "You will be required to log in into the account again.");
 
+    // TRANSLATOR: Tdlib crash dialog, primary content. Argument is a tdlib-provided error message.
+    // Please keep the string "tdlib" verbatim. Will be followed by a newline and more text.
     std::string details = formatMessage(_("tdlib error: {}"), std::string(message));
     details += '\n';
     details += formatMessage(dbMessage, PurpleTdClient::getBaseDatabasePath());
 
-    purple_notify_error(getPluginInfo(), _("Telegram plugin"),
-                        _("Fatal error encountered in telegram plugin"),
-                        details.c_str());
+    // TRANSLATOR: Tdlib crash dialog, title
+    purple_notify_error(getPluginInfo(), _("Fatal error encountered in telegram plugin"),
+                        details.c_str(), NULL);
 
     free(message);
     return FALSE; // this idle handler will not be called again
@@ -807,6 +869,8 @@ static void tdlibFatalErrorCallback(const char *message)
     g_idle_add(tdlibFatalErrorHandler, strdup(message));
     // The error must have come either from the poll thread or from one of the threads created by tdlib.
     // So, hang the thread to avoid crash.
+    // FIXME: This effectively kills entire libpurple, not just the account, and requires a restart.
+    // We should probably also add instructions on how to disable the account in accounts.xml.
     while (1) sleep(1000);
 }
 
@@ -832,17 +896,21 @@ static void tgprpl_init (PurplePlugin *plugin)
 
     GList *choices = NULL;
     if (!strcmp(AccountOptions::DownloadBehaviourDefault(), AccountOptions::DownloadBehaviourHyperlink)) {
+        // TRANSLATOR: Account settings, value for file downloads (hyperlink link file:///tmp/asdf)
         addChoice(choices, _("Inline (hyperlinks in chat)"), AccountOptions::DownloadBehaviourHyperlink);
+        // TRANSLATOR: Account settings, value for file downloads (file transfer dialog)
         addChoice(choices, _("Standard file transfers"), AccountOptions::DownloadBehaviourStandard);
     } else {
         addChoice(choices, _("Standard file transfers"), AccountOptions::DownloadBehaviourStandard);
-        addChoice(choices, _("Inline (hyperlinks is chat)"), AccountOptions::DownloadBehaviourHyperlink);
+        addChoice(choices, _("Inline (hyperlinks in chat)"), AccountOptions::DownloadBehaviourHyperlink);
     }
     
+    // TRANSLATOR: Account settings, key (choice)
     PurpleAccountOption *opt = purple_account_option_list_new (_("File downloads"),
                                                                AccountOptions::DownloadBehaviour, choices);
     prpl_info.protocol_options = g_list_append (prpl_info.protocol_options, opt);
 
+    // TRANSLATOR: Account settings, key (choice)
     opt = purple_account_option_string_new (_("Inline auto-download size limit, MB (0 for unlimited)"),
                                             AccountOptions::AutoDownloadLimit,
                                             AccountOptions::AutoDownloadLimitDefault);
@@ -851,23 +919,31 @@ static void tgprpl_init (PurplePlugin *plugin)
     static_assert(AccountOptions::BigDownloadHandlingDefault == AccountOptions::BigDownloadHandlingAsk,
                   "default choice must be first");
     choices = NULL;
+    // TRANSLATOR: Account settings, value for large file downloads
     addChoice(choices, _("Ask"), AccountOptions::BigDownloadHandlingAsk);
+    // TRANSLATOR: Account settings, value for large file downloads
     addChoice(choices, _("Discard"), AccountOptions::BigDownloadHandlingDiscard);
 
+    // TRANSLATOR: Account settings, key (choice)
     opt = purple_account_option_list_new (_("Bigger inline file downloads"), AccountOptions::BigDownloadHandling, choices);
     prpl_info.protocol_options = g_list_append (prpl_info.protocol_options, opt);
 
     static_assert(AccountOptions::AcceptSecretChatsDefault == AccountOptions::AcceptSecretChatsAsk,
                   "default choice must be first");
     choices = NULL;
+    // TRANSLATOR: Account settings, value for 'Accept secret chats'
     addChoice(choices, _("Ask"), AccountOptions::AcceptSecretChatsAsk);
+    // TRANSLATOR: Account settings, value for 'Accept secret chats'
     addChoice(choices, _("Always"), AccountOptions::AcceptSecretChatsAlways);
+    // TRANSLATOR: Account settings, value for 'Accept secret chats'
     addChoice(choices, _("Never"), AccountOptions::AcceptSecretChatsNever);
 
+    // TRANSLATOR: Account settings, key (choice)
     opt = purple_account_option_list_new (_("Accept secret chats"), AccountOptions::AcceptSecretChats, choices);
     prpl_info.protocol_options = g_list_append(prpl_info.protocol_options, opt);
 
 #ifndef NoLottie
+    // TRANSLATOR: Account settings, key (boolean)
     opt = purple_account_option_bool_new(_("Show animated stickers"), AccountOptions::AnimatedStickers,
                                          AccountOptions::AnimatedStickersDefault);
     prpl_info.protocol_options = g_list_append(prpl_info.protocol_options, opt);
@@ -881,21 +957,26 @@ static void requestTwoFactorAuth(PurpleConnection *gc, const char *primaryText, 
     PurpleRequestFields     *fields  = purple_request_fields_new();
     PurpleRequestFieldGroup *group   = purple_request_field_group_new(NULL);
 
+    // TRANSLATOR: 2FA settings, key
     PurpleRequestField *field = purple_request_field_string_new ("oldpw", _("Current password"), NULL, FALSE);
     purple_request_field_string_set_masked(field, TRUE);
     purple_request_field_group_add_field (group, field);
 
+    // TRANSLATOR: 2FA settings, key
     field = purple_request_field_string_new ("pw1", _("New password"), NULL, FALSE);
     purple_request_field_string_set_masked(field, TRUE);
     purple_request_field_group_add_field (group, field);
 
+    // TRANSLATOR: 2FA settings, key
     field = purple_request_field_string_new ("pw2", _("Repeat password"), NULL, FALSE);
     purple_request_field_string_set_masked(field, TRUE);
     purple_request_field_group_add_field (group, field);
 
+    // TRANSLATOR: 2FA settings, key
     field = purple_request_field_string_new ("hint", _("Password hint"), NULL, FALSE);
     purple_request_field_group_add_field (group, field);
 
+    // TRANSLATOR: 2FA settings, key
     field = purple_request_field_string_new ("email", _("Recovery e-mail"), email, FALSE);
     purple_request_field_group_add_field (group, field);
 
@@ -903,8 +984,12 @@ static void requestTwoFactorAuth(PurpleConnection *gc, const char *primaryText, 
 
     RequestData *data = new RequestData(purple_connection_get_account(gc));
     data->account = purple_connection_get_account(gc);
-    purple_request_fields (gc, _("Two-factor authentication"), primaryText, NULL, fields, _("OK"),
-                           G_CALLBACK(setTwoFactorAuth), _("Cancel"), G_CALLBACK(cancelRequest),
+    // TRANSLATOR: 2FA settings, title
+    purple_request_fields (gc, _("Two-factor authentication"), primaryText, NULL, fields,
+                           // TRANSLATOR: 2FA settings, alternative is "Cancel"
+                           _("OK"), G_CALLBACK(setTwoFactorAuth),
+                           // TRANSLATOR: 2FA settings, alternative is "OK"
+                           _("Cancel"), G_CALLBACK(cancelRequest),
                            purple_connection_get_account(gc), NULL, NULL, data);
 }
 
@@ -912,6 +997,7 @@ static int reRequestTwoFactorAuth(gpointer user_data)
 {
     std::unique_ptr<RequestData> request(static_cast<RequestData *>(user_data));
     requestTwoFactorAuth(purple_account_get_connection(request->account),
+                        // TRANSLATOR: 2FA settings, primary content (after mistype)
                         _("Please enter same password twice"), request->stringData.c_str());
     return FALSE; // this idle handler will not be called again
 }
@@ -942,6 +1028,7 @@ static void setTwoFactorAuth(RequestData *data, PurpleRequestFields* fields)
 static void configureTwoFactorAuth(PurplePluginAction *action)
 {
     PurpleConnection *gc = static_cast<PurpleConnection *>(action->context);
+    // TRANSLATOR: 2FA settings, primary content
     requestTwoFactorAuth(gc, _("Enter new password and recovery e-mail address"), NULL);
 }
 
@@ -950,6 +1037,7 @@ static GList *tgprpl_actions (PurplePlugin *plugin, gpointer context)
     GList *actionsList = NULL;
     PurplePluginAction *action;
 
+    // TRANSLATOR: 2FA settings, title
     action = purple_plugin_action_new(_("Configure two-factor authentication..."),
                                       configureTwoFactorAuth);
     actionsList = g_list_append(actionsList, action);

--- a/test/private-chat-test.cpp
+++ b/test/private-chat-test.cpp
@@ -867,7 +867,7 @@ TEST_F(PrivateChatTest, ReplyToOldMessage_FetchFailed)
         ServGotImEvent(
             connection,
             purpleUserName(0),
-            fmt::format(replyPattern, "unknown user", "[message unavailable]", "reply"),
+            fmt::format(replyPattern, "Unknown user", "[message unavailable]", "reply"),
             PURPLE_MESSAGE_RECV,
             date
         )


### PR DESCRIPTION
This makes it easier for translators.

In the source code, the comments may seem obvious. However, a translater usually only sees the string itself, without *any* context.

Example: What does `Voice call` mean? Oh, it's a "Dialog title of an error message", great!

I took the liberty to mark some additional strings for translation that appear to have been forgotten. I did *not* check that all strings are now included. I should probably do that at some point, but not right now, my brain is fried from writing these context-comments.

I also took the liberty to **replace some overly broad dialog titles**. For example, there was a dialog with the title "Error". Now it's "Failed to delete group or channel", which is much more to the point.

I haven't updated the potfile because there are likely more changes coming anyway.