### PR TITLE
Fix handling of read receipts option

### DIFF
--- a/tdlib-purple.cpp
+++ b/tdlib-purple.cpp
@@ -1018,8 +1018,8 @@ static void tgprpl_init (PurplePlugin *plugin)
 
     if (canDisableReadReceipts()) {
         opt = purple_account_option_bool_new ("Send read receipts",
-                                              AccountOptions::EnableSecretChats,
-                                              AccountOptions::EnableSecretChatsDefault);
+                                              AccountOptions::ReadReceipts,
+                                              AccountOptions::ReadReceiptsDefault);
         prpl_info.protocol_options = g_list_append(prpl_info.protocol_options, opt);
     }
 }


### PR DESCRIPTION
Now read receipts can be adjusted as intended from bitlbee/spectrum.

The account option were accidentally copypasted and in bitlbee it wasn't
permitted to set them.  This PR fix that and now they can be turned on/off from
bitlbee too.