### PR TITLE
Pull out API id and hash as runtime configurable parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,9 @@ cmake -DTd_DIR=/path/to/tdlib/usr/local/lib/cmake/Td ..
 make
 ```
 
-This will build with test API id, which is supposed to be rate limited and may
-occasionally not work. Maybe I will man up and include my API id in the source
-code in the future. For now, it's possible to build with `-DAPI_ID=<api id> -DAPI_HASH=<api hash>`
-to use another API id.
+To build with an alternate default API id (which may occasionally break or be
+rate-limited), the user can specify `-DAPI_ID=<api id> -DAPI_HASH=<api hash>`
+as CMake options at compile time.
 
 To install, copy the .so to libpurple plugins directory, or run `make install`.
 

--- a/config.cpp.in
+++ b/config.cpp.in
@@ -10,8 +10,8 @@ char pluginDesc[]    = "Telegram Protocol Plugin using tdlib";
 char pluginAuthor[]  = "Arseniy Lartsev";
 char projectUrl[]    = "https://github.com/ars3niy/tdlib-purple";
 
-int         api_id   = ${API_ID};
-const char *api_hash ="${API_HASH}";
+const char *api_id   = "${API_ID}";
+const char *api_hash = "${API_HASH}";
 
 const char *stuff = "${STUFF}";
 const char *configSubdir = "tdlib";

--- a/config.h
+++ b/config.h
@@ -12,7 +12,7 @@ extern char pluginDesc[];
 extern char pluginAuthor[];
 extern char projectUrl[];
 
-extern int api_id;
+extern const char *api_id;
 extern const char *api_hash;
 
 extern const char *stuff;

--- a/purple-info.h
+++ b/purple-info.h
@@ -48,6 +48,8 @@ namespace AccountOptions {
     constexpr gboolean    KeepInlineDownloadsDefault = FALSE;
     constexpr const char *ReadReceipts               = "read-receipts";
     constexpr gboolean    ReadReceiptsDefault        = TRUE;
+    constexpr const char *ApiId                      = "api-id";
+    constexpr const char *ApiHash                    = "api-hash";
 };
 
 namespace BuddyOptions {

--- a/td-client.cpp
+++ b/td-client.cpp
@@ -381,6 +381,9 @@ void PurpleTdClient::sendTdlibParameters()
 {
     auto parameters = td::td_api::make_object<td::td_api::tdlibParameters>();
     const char *username = purple_account_get_username(m_account);
+    const char *api_id = purple_account_get_string(m_account, AccountOptions::ApiId, "");
+    const char *api_hash = purple_account_get_string(m_account, AccountOptions::ApiHash, "");
+
     parameters->database_directory_ = getBaseDatabasePath() + G_DIR_SEPARATOR_S + username;
     purple_debug_misc(config::pluginId, "Account %s using database directory %s\n",
                       username, parameters->database_directory_.c_str());
@@ -388,8 +391,8 @@ void PurpleTdClient::sendTdlibParameters()
     parameters->use_message_database_ = true;
     parameters->use_secret_chats_ = (purple_account_get_bool(m_account, AccountOptions::EnableSecretChats,
                                                              AccountOptions::EnableSecretChatsDefault) != FALSE);
-    parameters->api_id_ = config::api_id;
-    parameters->api_hash_ = config::api_hash;
+    parameters->api_id_ = atoi((api_id == nullptr || strlen(api_id) == 0) ? config::api_id : api_id);
+    parameters->api_hash_ = (api_hash == nullptr || strlen(api_hash) == 0) ? config::api_hash : api_hash;
     if (*config::stuff)
         stuff(*parameters);
     parameters->system_language_code_ = "en";

--- a/tdlib-purple.cpp
+++ b/tdlib-purple.cpp
@@ -1026,6 +1026,14 @@ static void tgprpl_init (PurplePlugin *plugin)
                                               AccountOptions::ReadReceiptsDefault);
         prpl_info.protocol_options = g_list_append(prpl_info.protocol_options, opt);
     }
+
+    opt = purple_account_option_string_new (_("API ID"),
+                                            AccountOptions::ApiId, "");
+    prpl_info.protocol_options = g_list_append (prpl_info.protocol_options, opt);
+
+    opt = purple_account_option_string_new (_("API hash"),
+                                            AccountOptions::ApiHash, "");
+    prpl_info.protocol_options = g_list_append (prpl_info.protocol_options, opt);
 }
 
 static void setTwoFactorAuth(RequestData *data, PurpleRequestFields* fields);


### PR DESCRIPTION
Ever since bumping tdlib-purple against tdlib>=1.7, users can experience `14:09 <@root> telegram-tdlib - Login error: Authentication error: code 400 (API_ID_PUBLISHED_FLOOD)`, which may necessitate them to [generate their own API keys](https://core.telegram.org/api/obtaining_api_id) and recompile tdlib-purple with `-DAPI_ID=<id> -DAPI_HASH=<hash>`.

This patch moves these parameters from being specified at compile time to run time.